### PR TITLE
Seq mode plugin enhancement

### DIFF
--- a/packages/annotorious-sequence-mode/public/index.html
+++ b/packages/annotorious-sequence-mode/public/index.html
@@ -75,17 +75,69 @@
           locale: 'auto'
         });
 
-        Annotorious.SequenceMode(anno, viewer);
+        const initialAnnotations = {
+          "640px-Hallstatt.jpg": [
+            {
+              "type": "Annotation",
+              "body": [
+                {
+                  "type": "TextualBody",
+                  "value": "ChurchTower",
+                  "purpose": "tagging"
+                }
+              ],
+              "target": {
+                "source": "http://localhost:3000/640px-Hallstatt.jpg",
+                "selector": {
+                  "type": "FragmentSelector",
+                  "conformsTo": "http://www.w3.org/TR/media-frags/",
+                  "value": "xywh=pixel:180,10.5,66,280"
+                }
+              },
+              "@context": "http://www.w3.org/ns/anno.jsonld",
+              "id": "#bd970b23-231e-4535-b50d-ef183f5e6c10"
+            }
+          ],
+          "wadirum.jpg": [
+            {
+              "type": "Annotation",
+              "body": [
+                {
+                  "type": "TextualBody",
+                  "value": "FadedStone",
+                  "purpose": "tagging"
+                }
+              ],
+              "target": {
+                "source": "http://localhost:3000/wadirum.jpg",
+                "selector": {
+                  "type": "FragmentSelector",
+                  "conformsTo": "http://www.w3.org/TR/media-frags/",
+                  "value": "xywh=pixel:524.2874755859375,281.10626220703125,75.1265869140625,39.9609375"
+                }
+              },
+              "@context": "http://www.w3.org/ns/anno.jsonld",
+              "id": "#ca9edde7-9e9f-4c0e-9edc-8c71e8b1aab6"
+            }
+          ]
+        };
+
+        Annotorious.SequenceMode(anno, viewer, {initialAnnotations});
+
+        viewer.addHandler('open', () => {
+          console.log("All Annotations:", anno.getAllAnnotations());
+        });
       }
     </script>
   </head>
   <body>
     <div class="column">
-      <h1>Annotorious | Sequence Mode Example</h1>
+      <h1>Annotorious-OpenSeadragon | Sequence Mode Plugin</h1>
       <p class="instructions">
-        In Sequence Mode, on page change ,the annotation layer is cleared and all the annotations
-        are removed, its upto the client application to handle pagination. This page contains a
-        simple example of handling pagination.
+        When this plugin is used with OpenSeadragon and the osd viewer is in sequence mode,
+        the annotation layer is cleared and all the annotations are removed, this plugin implements
+        a simple pagination. The function <code>getAllAnnotations</code> is also added to the
+        annotator which can be used to get all the annotations pages.
       </p>
       <div id="openseadragon" style="width: 640px; height: 480px;"></div>
     </div>

--- a/packages/annotorious-sequence-mode/src/index.js
+++ b/packages/annotorious-sequence-mode/src/index.js
@@ -31,7 +31,7 @@ const SequenceModePlugin = (anno, viewer, opts={}) => {
         pagedAnnotations[currentPage][annotation.id] = annotation;
       });
     }
-    anno.setAnnotations(Object.values(pagedAnnotations[currentPage]));
+    anno.setAnnotations(Object.values(pagedAnnotations[currentPage]||{}));
   });
 
 

--- a/packages/annotorious-sequence-mode/src/index.js
+++ b/packages/annotorious-sequence-mode/src/index.js
@@ -1,6 +1,7 @@
-const SequenceModePlugin = (anno, viewer) => {
+const SequenceModePlugin = (anno, viewer, opts={}) => {
 
   const pagedAnnotations = [];
+  const {initialAnnotations} = opts;
 
   const addOrUpdateAnnotationPages = (annotation) => {
     const currentPage = viewer.currentPage();
@@ -21,16 +22,30 @@ const SequenceModePlugin = (anno, viewer) => {
   anno.on('updateAnnotation', addOrUpdateAnnotationPages);
   anno.on('deleteAnnotation', removePagedAnnotation);
 
-
-  viewer.addHandler('page', ({page}) => {
-    if (pagedAnnotations[page]) {
-      anno.setAnnotations(Object.values(pagedAnnotations[page]))
-    } else {
-      anno.cancelSelected();
-      anno.clearAnnotations();
+  viewer.addHandler('open', () => {
+    const tileSourceURL = viewer.world.getItemAt(0).source.url;
+    const currentPage = viewer.currentPage();
+    if(!pagedAnnotations[currentPage] && initialAnnotations?.[tileSourceURL]) {
+      pagedAnnotations[currentPage] = {};
+      initialAnnotations[tileSourceURL].forEach(annotation => {
+        pagedAnnotations[currentPage][annotation.id] = annotation;
+      });
     }
+    anno.setAnnotations(Object.values(pagedAnnotations[currentPage]));
   });
 
-}
+
+  viewer.addHandler('page', () => {
+      anno.cancelSelected();
+      anno.clearAnnotations();
+  });
+
+  anno.getAllAnnotations = () => {
+    return pagedAnnotations
+      .filter(val => !!val)
+      .map(Object.values)
+      .flat();
+  };
+};
 
 export default SequenceModePlugin;


### PR DESCRIPTION
This addition will:

- Monkey patch the annotator to add a function called `getAllAnnotations` mode that will simply provide annotations
for all images loaded in the viewer.

- Add Option to provide initial Annotations based on URL: An initial set of annotations to be loaded into the viewer once we
have the viewer open in sequence mode and an Image with that URL is open can be provided as options