### PR TITLE
BetterPloygon: switch from key code to key name for better cross-platform compatibility

### DIFF
--- a/plugins/annotorious-better-polygon/src/ImEditablePolygon.js
+++ b/plugins/annotorious-better-polygon/src/ImEditablePolygon.js
@@ -193,7 +193,7 @@ export default class ImEditablePolygon extends EditableShape {
   }
 
   onKeyUp = evt => {
-    if (evt.which === 46 && this.deleteSelected()) {
+    if ((evt.key == "Backspace" || evt.key == "Delete") && this.deleteSelected()) {
       evt.preventDefault();
       evt.stopImmediatePropagation();
     }


### PR DESCRIPTION
Deleting a handle is not possible on Mac because the key code used in code (`46`) does not exist. A more cross-platform way to do it would be to use key name instead of their code.
