### PR TITLE
update menu to have setting options

### DIFF
--- a/plugins/annotorious-toolbar/src/icons/Mouse.js
+++ b/plugins/annotorious-toolbar/src/icons/Mouse.js
@@ -1,0 +1,14 @@
+export default () => {
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+
+  svg.setAttribute('viewBox', '0 0 320 512');
+
+  svg.innerHTML = `
+    <g>
+		<path d="M0 55.2V426c0 12.2 9.9 22 22 22c6.3 0 12.4-2.7 16.6-7.5L121.2 346l58.1 116.3c7.9 15.8 27.1 22.2 42.9 14.3s22.2-27.1 14.3-42.9L179.8 320H297.9c12.2 0 22.1-9.9 22.1-22.1c0-6.3-2.7-12.3-7.4-16.5L38.6 37.9C34.3 34.1 28.9 32 23.2 32C10.4 32 0 42.4 0 55.2z"/>
+	</g>
+  `;
+  
+  return svg;
+}
+

--- a/plugins/annotorious-toolbar/src/index.css
+++ b/plugins/annotorious-toolbar/src/index.css
@@ -6,8 +6,6 @@
   background-color:transparent;
   border-radius:4px;
   padding:8px;
-  width:45px;
-  height:45px;
 }
 
 .a9s-toolbar-btn:hover {
@@ -16,12 +14,13 @@
 
 .a9s-toolbar-btn-inner {
   display:flex;
+  align-items: center;
 }
 
 .a9s-toolbar-btn svg {
   overflow:visible;
-  width:100%;
-  height:100%;
+  width:45px;
+  height:45px;
 }
 
 .a9s-toolbar-btn svg * {
@@ -36,12 +35,20 @@
   stroke:#000;
 }
 
+.a9s-toolbar-btn.mouse path{
+  fill:#000;
+}
+
 .a9s-toolbar-btn.active {
   background-color:rgba(0,0,0,0.3);
 }
 
 .a9s-toolbar-btn.active svg * {
   stroke:rgba(255,255,255,0.6);
+}
+
+.a9s-toolbar-btn.active.mouse path{
+  fill: rgba(255,255,255,0.6);
 }
 
 .a9s-toolbar-btn.active g.handles circle {

--- a/plugins/annotorious-toolbar/src/index.js
+++ b/plugins/annotorious-toolbar/src/index.js
@@ -6,10 +6,12 @@ import createFreehand from './icons/Freehand';
 import createPoint from './icons/Point';
 import createTiltedBox from './icons/TiltedBox';
 import createLine from './icons/Line';
+import createMouse from './icons/Mouse';
 
 import './index.css';
 
 const ICONS = {
+  'mouse': createMouse(),
   'rect': createRectangle(),
   'polygon': createPolygon(),
   'circle': createCircle(),
@@ -18,6 +20,18 @@ const ICONS = {
   'point': createPoint(), 
   'annotorious-tilted-box': createTiltedBox(),
   'line': createLine()
+}
+
+const ICONLABEL = {
+  'mouse': '',
+  'rect': 'Rectangle',
+  'polygon': 'Polygon',
+  'circle': 'Circle',
+  'ellipse': 'Ellipse',
+  'freehand': 'Freehand',
+  'point': 'Point',
+  'annotorious-tilted-box': 'Angled Box',
+  'line': 'Line'
 }
 
 // IE11 doesn't support adding/removing classes to SVG elements except 
@@ -33,7 +47,7 @@ const removeClass = (el, className) => {
   el.setAttribute('class', classNames.join(' '));
 }
 
-const Toolbar = (anno, container) => {
+const Toolbar = (anno, container, settings={}) => {
   // Bit of a hack...
   const isOSDPlugin = !!anno.fitBounds;
 
@@ -51,6 +65,14 @@ const Toolbar = (anno, container) => {
     addClass(button, 'active');
   }
 
+  const enableDrawing = (toolId, anno) => {
+    toolId = toolId ? toolId : toolbar.querySelector('.a9s-toolbar-btn.active').classList[1];
+    if (isOSDPlugin && toolId != 'mouse'){
+      anno.setDrawingEnabled(true);
+    } else if (isOSDPlugin && toolId == 'mouse') {
+      anno.setDrawingEnabled(false);
+    }
+  }
   // Helper to create one tool button 
   const createButton = (toolId, isActive) => {
     const icon = ICONS[toolId];
@@ -65,31 +87,55 @@ const Toolbar = (anno, container) => {
 
       const inner = document.createElement('span');
       inner.className = 'a9s-toolbar-btn-inner';
-
       inner.appendChild(icon);
 
+      if (settings['withLabel'] && ICONLABEL[toolId]) {
+        inner.innerHTML += `<span class="a9s-toolbar-btn-label">${ICONLABEL[toolId]}</span>`;
+      }
+ 
       button.addEventListener('click', () => {
         setActive(button);
-        anno.setDrawingTool(toolId);
-
-        if (isOSDPlugin)
-          anno.setDrawingEnabled(true);
+        if (toolId != 'mouse'){
+          anno.setDrawingTool(toolId);
+        }
+        enableDrawing(toolId, anno)
       });
+
+
 
       button.appendChild(inner);
       toolbar.appendChild(button);
+      if (settings['withMouse']){
+        anno.on('cancelSelected', function() {
+          enableDrawing('', anno);
+        });
+        anno.on('createAnnotation', function(annotation) {
+          enableDrawing('', anno);
+        });
+      
+        anno.on('updateAnnotation', function(annotation) {
+          enableDrawing('', anno);
+        });
+
+        anno.on('deleteAnnotation', function(annotation) {
+          enableDrawing('', anno);
+        });
+      }
     }
   }
-  
+  if (settings['withMouse']){
+    createButton('mouse', true);
+  }
   anno.listDrawingTools().forEach((toolId, idx) => {
     // In standard version, activate first button
     const activateFirst = !isOSDPlugin && idx === 0; 
     createButton(toolId, activateFirst);        
   });
 
-  if (isOSDPlugin)
-    anno.on('createSelection', clearActive);
 
+  if (isOSDPlugin && !settings['withMouse']){
+      anno.on('createSelection', clearActive);
+  }
   container.appendChild(toolbar);
 }
 

--- a/plugins/annotorious-toolbar/src/index.js
+++ b/plugins/annotorious-toolbar/src/index.js
@@ -98,6 +98,15 @@ const Toolbar = (anno, container, settings={}) => {
         if (toolId != 'mouse'){
           anno.setDrawingTool(toolId);
         }
+
+        if (settings['infoElement']) {
+          const infoElement = document.getElementbyId(settings['infoElement']);
+          if (toolId == 'polygon'){
+            infoElement.innerHTML = 'To stop Polygon annotation selection double click.';
+          } else {
+            infoElement.innerHTML = '';
+          }
+        }
         enableDrawing(toolId, anno)
       });
 

--- a/plugins/annotorious-toolbar/src/index.js
+++ b/plugins/annotorious-toolbar/src/index.js
@@ -100,11 +100,10 @@ const Toolbar = (anno, container, settings={}) => {
         }
 
         if (settings['infoElement']) {
-          const infoElement = document.getElementbyId(settings['infoElement']);
           if (toolId == 'polygon'){
-            infoElement.innerHTML = 'To stop Polygon annotation selection double click.';
+            settings['infoElement'].innerHTML = 'To stop Polygon annotation selection double click.';
           } else {
-            infoElement.innerHTML = '';
+            settings['infoElement'].innerHTML = '';
           }
         }
         enableDrawing(toolId, anno)


### PR DESCRIPTION
@rsimon I could use some feedback for a couple things, basically the setting wold allow the images to be labeled. It would also allow users to enable a mouse which would mean they wouldn't have to keep clicking on the shapes in order to create a new annotation. Let me know what you think.