### PR TITLE
for toolbar plugin, set type attribute to "button" avoid submit form

### DIFF
--- a/plugins/annotorious-toolbar/src/index.js
+++ b/plugins/annotorious-toolbar/src/index.js
@@ -79,6 +79,7 @@ const Toolbar = (anno, container, settings={}) => {
 
     if (icon) {
       const button = document.createElement('button');
+      button.type = "button";
 
       if (isActive)
         button.className = `a9s-toolbar-btn ${toolId} active`;


### PR DESCRIPTION
if toolbar_container in form tag, when click toolbar button, the form will be submitted， so set type attribute to "button" avoid submit form